### PR TITLE
DETAILS var anypiab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,28 @@ matrix:
         - cd anypiab/build
         - cmake ..
         - make
+    - name: "emscripten-anypiab-mac"
+      os: osx
+      osx_image: xcode11.4
+      addons:
+        homebrew:
+          packages:
+            - cmake
+            - boost
+            - emscripten
+      script:
+        # Needed to use Homebrew's emscripten
+        - export LLVM=/usr/local/opt/emscripten/libexec/llvm/bin
+        - export BINARYEN=/usr/local/opt/binaryen
+        - wget -q "https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.zip"
+        - unzip -q boost_1_64_0.zip
+        - cd boost_1_64_0
+        - ./bootstrap.sh
+        - ./b2 toolset=emscripten link=static runtime-link=static --with-date_time
+        - export BOOST_INCL=`pwd`
+        - export BOOST_LIB=`pwd`/stage/lib
+        - cd ..
+        - mkdir anypiab/build
+        - cd anypiab/build
+        - emcmake cmake -DBOOST_INCLUDEDIR=$BOOST_INCL -DBOOST_LIBRARYDIR=$BOOST_LIB ..
+        - make -j2

--- a/anypiab/CMakeLists.txt
+++ b/anypiab/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 add_executable(${PROJECT_NAME} ${SOURCES})
 
 if(NOT DEFINED ANYPIATEST)
-    add_compile_definitions("ANYPIAB")
+    add_compile_definitions("ANYPIAB" "DETAILS")
 endif(NOT DEFINED ANYPIATEST)
 
 # On Linux, the order of these libraries matters!

--- a/anypiab/CMakeLists.txt
+++ b/anypiab/CMakeLists.txt
@@ -2,6 +2,23 @@ cmake_minimum_required(VERSION 3.10)
 
 project(anypiab)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+    # CMake's Emscripten settings search for everything under
+    # the toolchain prefix, this breaks Boost find_package.
+    # Turn this off just around the Boost find_package.
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
+
+    # On macOS Boost libraries are built as .bc and .dylib,
+    # but CMake Emscripten's settings for .so and .a by default
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES .bc .dylib)
+    endif()
+
+    # Create .html launcher as well
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+endif()
+
 add_subdirectory(../oactobjs32/misc ${CMAKE_BINARY_DIR}/misc)
 add_subdirectory(../oactobjs32/piadata ${CMAKE_BINARY_DIR}/piadata)
 add_subdirectory(../oactobjs32/piaout ${CMAKE_BINARY_DIR}/piaout)
@@ -14,6 +31,11 @@ set(SOURCES
 )
 
 find_package(Boost 1.64.0 REQUIRED COMPONENTS date_time)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 

--- a/anypiab/anypiab.vcxproj
+++ b/anypiab/anypiab.vcxproj
@@ -118,7 +118,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\oactobjs32;..\oactobjs32\include;..\oactobjs32\windows;..\oactobjs32\boost_1_64_0;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;ANYPIAB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;ANYPIAB;DETAILS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>


### PR DESCRIPTION
I noticed on the main linux/macOS build if you add a DETAILS e.g. `add_compile_definitions("ANYPIAB" "DETAILS")` then it does not build, seemingly because of MFC again. Maybe they put the DETAILS behind macros for linux's sake. Let's see if Windows works in the test.

https://www.ssa.gov/OACT/anypia/anypiab.html

> If anypiab is compiled with DETAILS defined, then there is a file named details.out with detailed output.

(Didn't intentionally base this on #6 but I guess we'll see what happens with mac emscripten as well!)